### PR TITLE
Additional permissions test when accessing REST API response

### DIFF
--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -30,7 +30,7 @@ def test_login_form(client):
 def test_user_staff_permissions_request():
     # Creating a user and setting their staff value to be false.
     user = User.objects.create_user(username='testuser', password='testpassword')
-    user.is_staff = False;
+    user.is_staff = False
 
     # Defining a request to the modelworx path and assigning a user to it.
     request = APIRequestFactory().get('modelworx')
@@ -47,7 +47,7 @@ def test_user_staff_permissions_request():
 def test_user_no_staff_permissions_request():
     # Defining the user and making them a staff member.
     user = User.objects.create_user(username='testuser', password='testpassword')
-    user.is_staff = True;
+    user.is_staff = True
 
     # Creating the request and assigning the user to it.
     request = APIRequestFactory().get('modelworx')

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -2,6 +2,9 @@
 import pytest
 from django.urls import reverse
 from django.contrib.auth.models import User
+from rest_framework.test import APIRequestFactory
+from .permissions import DetermineIfStaffPermissions
+
 
 # Create your tests here.
 def test_func():
@@ -22,3 +25,37 @@ def test_login_form(client):
     #
     #assert response.status_code == 302  # Redirect status code
     #assert response.url == reverse('') # Need to specify an expected login page 
+
+@pytest.mark.django_db
+def test_user_staff_permissions_request():
+    # Creating a user and setting their staff value to be false.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    user.is_staff = False;
+
+    # Defining a request to the modelworx path and assigning a user to it.
+    request = APIRequestFactory().get('modelworx')
+    request.user = user
+
+    # Using the permissions.py class to check if permissions are met.
+    determinePermissions = DetermineIfStaffPermissions()
+    permissions = determinePermissions.has_permission(request, None)
+
+    # The assertion is that permissions weren't given.
+    assert permissions == False
+
+@pytest.mark.django_db
+def test_user_no_staff_permissions_request():
+    # Defining the user and making them a staff member.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    user.is_staff = True;
+
+    # Creating the request and assigning the user to it.
+    request = APIRequestFactory().get('modelworx')
+    request.user = user
+
+    # Using the permissions.py class to check if the user has permissions to access the page.
+    determinePermissions = DetermineIfStaffPermissions()
+    permissions = determinePermissions.has_permission(request, None)
+
+    # Asserting that the user does have permissions to view the page.
+    assert permissions == True


### PR DESCRIPTION
Test #27
Included additional permissions tests to verify only staff could view the REST API response.

1. Testing permissions for a user without staff permissions. Gave the user a test username and password. The request goes to the modelworx API response. Asserting that permissions are not given.
2. Testing permissions for a user with staff permissions. Gave the user a test username and password. The request goes to the modelworx API response. Asserting that permissions are given.