### PR TITLE
Create auth token from account page

### DIFF
--- a/proj/automodeler/serializer.py
+++ b/proj/automodeler/serializer.py
@@ -2,16 +2,16 @@
 # The view set will be used in the modelworx\urls.py file to show user data in an API response.
 from django.contrib.auth.models import User
 from rest_framework import serializers, viewsets
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
 from .permissions import DetermineIfStaffPermissions
 
 class ModelWorxSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User # Defining a model using the Django User model.
-        fields = ['date_joined', 'last_login', 'is_active', 'is_staff', 'username', 'url',] # Chose important fields to be collected and displayed at a modelworx path.
+        fields = ['date_joined', 'last_login', 'is_active', 'is_staff', 'username'] # Chose important fields to be collected and displayed at a modelworx path.
 
 class ModelWorxViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all() # Creating a list of users that will be serialized by the ModelWorkxSerializer class to get chosen fields.
     serializer_class = ModelWorxSerializer # Setting the serializer to the ModelWorxSerializer class.
-    authentication_classes = [SessionAuthentication, BasicAuthentication] # Ensuring someone is signed to show them the complete API response.
+    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication] # Ensuring someone is signed to show them the complete API response.
     permission_classes = [DetermineIfStaffPermissions] # Checking that the user has "is_staff" set to true before showing them the API response.

--- a/proj/automodeler/templates/automodeler/account.html
+++ b/proj/automodeler/templates/automodeler/account.html
@@ -1,0 +1,12 @@
+{% include "base/header.html" %}
+{% include "base/navbar.html" %}
+
+<h1>Account Page - {{ user.username }}</h1>
+
+<form method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    <p> {{ token }} </p>
+    <input type="submit" value="Receive Token">
+</form>
+
+{% include "base/footer.html" %}

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from rest_framework.test import APIRequestFactory
 from .permissions import DetermineIfStaffPermissions
+from .views import account
 
 
 # Create your tests here.
@@ -33,6 +34,27 @@ def test_login_form(client):
     #
     #assert response.status_code == 302  # Redirect status code
     #assert response.url == reverse('') # Need to specify an expected login page 
+
+@pytest.mark.django_db
+def test_account_page(client):
+    # Defining the url that will be navigated to.
+    url = reverse('account')
+
+    # Getting the response when the client navigates to the URL.
+    response = client.get(url)
+    
+    # The response should redirect the client to the login page.
+    assert response.status_code == 302
+
+    # Setting up a user and logging them into the client so they are authenticated.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    client.login(username='testuser', password='testpassword')
+    
+    # Getting the response when the client navigates to the URL.
+    response = client.get(url)
+
+    # The response should open the account page successfully.
+    assert response.status_code == 200
 
 @pytest.mark.django_db
 def test_user_staff_permissions_request():
@@ -67,3 +89,4 @@ def test_user_no_staff_permissions_request():
 
     # Asserting that the user does have permissions to view the page.
     assert permissions == True
+    

--- a/proj/automodeler/urls.py
+++ b/proj/automodeler/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("upload/", views.upload, name="upload"),
     path("dataset/<int:dataset_id>", views.dataset, name="dataset"),
+    path("account/", views.account, name="account"),
 ]

--- a/proj/modelworx/settings.py
+++ b/proj/modelworx/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'accounts', # Custom accounts project to create custom views; Works alongside the auth middleware
     'modelworx',
     'rest_framework',
+    'rest_framework.authtoken',
 ]
 
 MIDDLEWARE = [
@@ -87,6 +88,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ]
 }
 

--- a/proj/modelworx/urls.py
+++ b/proj/modelworx/urls.py
@@ -20,7 +20,7 @@ from rest_framework import routers
 from automodeler.serializer import ModelWorxViewSet
 
 router = routers.DefaultRouter() # Defining a router from the default rest framework router.
-router.register('modelworx', ModelWorxViewSet) # Routing the serializer data to the modelworx path to be displayed.
+router.register('modelworx', ModelWorxViewSet, basename='modelworx') # Routing the serializer data to the modelworx path to be displayed.
 
 urlpatterns = [
     path("automodeler/", include("automodeler.urls")),

--- a/proj/templates/base/navbar.html
+++ b/proj/templates/base/navbar.html
@@ -46,13 +46,15 @@
         </li>
         {% else %}
         <li class="nav-item">
+          <a class="nav-link" href="{% url 'account' %}">Account</a>
+        </li>
+        <li class="nav-item">
             <form action="/accounts/logout/" method="post">
                 {% csrf_token %}
                 <button class="nav-link" type="submit" aria-current="page">Logout</a>
             </form>
         </li>
          {% endif %}
-
         
       </ul>
       <form class="d-flex" role="search">


### PR DESCRIPTION
Associated with the two GitHub issues #67 & #68.

An account button was added to the navbar and can only be seen when an authenticated user is signed in. Clicking on it navigates someone to an account page. The page says it is an account page and shows a user's username. Clicking a "Receive Token" button assigns an authorization token to the user or gets it if they already have one. The key for the authorization token is displayed on the account page.