### PR TITLE
Accounts test

### DIFF
--- a/proj/accounts/tests.py
+++ b/proj/accounts/tests.py
@@ -1,54 +1,5 @@
 import pytest
-from django.urls import reverse, reverse_lazy
-from django.contrib.auth.models import User
 
 from . import views
 
 # Create your tests here.
-@pytest.mark.django_db
-def test_login_logout(client):
-    # Create test user; 
-    user = User.objects.create_user(username='testuser', password='testpassword')
-    assert not user.is_superuser
-
-    # Test GET on login page
-    url = reverse('login')
-    response = client.get(url)
-    assert response.status_code == 200
-
-    response = client.post(url, {'username': 'testuser', 'password': 'testpassword'})
-    assert response.status_code == 302
-    
-    # Need to fix this; currently it's not able to reverse match this url
-    # assert response.url == reverse("/automodeler/") 
-    
-    # Asserts that the session id is equal to the user.id
-    assert client.session['_auth_user_id'] == str(user.id)
-    
-    # Logout usser and test
-    url = reverse('logout')
-    response = client.post(url)
-    assert '_auth_user_id' not in client.session
-    
-    # Assert redirect after logout
-    assert response.status_code == 302
-    
-    # Need to fix this; currently it's not able to reverse match this url similar to the one above
-    # assert response.url == reverse("/automodeler/") 
-    
-    # Delete the testuser
-    user.delete()
-    
-
-@pytest.mark.django_db
-def test_signup(client):
-    username = 'testuser'
-    password1 = 'testpassword'
-    password2 = 'testpassword'
-    page = reverse('signup')
-    url = client.get(page)
-    response = client.post(page, {'username': username, 'password1': password1, 'password2': password2})
-    # Proper response will redirect to login page
-    assert response.status_code == 302
-    
-

--- a/proj/accounts/tests/account_tests.py
+++ b/proj/accounts/tests/account_tests.py
@@ -122,9 +122,11 @@ def test_signup_login_logout(client):
     assert response.headers['Location'] == reverse('index')
     
     # Verify redirect to login since user is no longer authenticated
-    response = client.get(reverse('index'))
+    response = client.get(reverse('dataset_collection'))
     assert response.status_code == 302
-    assert response.headers['Location'] == reverse('login')
+    #'accounts/login/?next=/automodeler/dataset_collection/''
+    expected_redirecturi = "".join([reverse('login'), "?next=", reverse('dataset_collection')])
+    assert response.headers['Location'] == expected_redirecturi
 
 
     


### PR DESCRIPTION
Update to the account_tests.py.

Changes to index that no longer required authentication made it no longer a valid test page for the test case.

The page selected (dataset_collections) uses the @login_required decorator.  This utilizes a GET parameter for the redirect URI so the 'Location' header was not a simple reverse selection for the redirect URL check.  The test has been changed to reflect this.