### PR TITLE
API Upload Request

### DIFF
--- a/api_requests/api_upload_request.py
+++ b/api_requests/api_upload_request.py
@@ -1,0 +1,28 @@
+import requests
+
+def api_upload_request():
+    '''
+    This function makes an API request to upload a dataset if the user is authenticated.
+    The csv file and name are expected to be changed with each upload.
+    A response will be printed to let the user know if an upload was successful.
+    '''
+    # The url is where the API request is made and the token authenticates the user.
+    url = "http://localhost:8000/automodeler/upload/api"
+    token = "6aa53ad83773ba8a42834ff9317933759ed0e86b"
+
+    # Defining the path for the csv file and name of the dataset.
+    csv_file = "C:\\Users\\jpdun\\Desktop\\personality_dataset.csv"
+    name = "API Upload Request"
+
+    # Making variables for the csv file, name, and token so they can be passed in the response.
+    files = {"csv_file": open(csv_file, "rb")}
+    data = {"name": name}
+    headers = { "Authorization": "Token " + token}
+            
+    # Getting the response after the API request is made and printing it to know if the upload was successful.
+    response = requests.post(url=url, headers=headers, files=files, data=data)
+    print(response.text)
+
+# The main method which is used to run the application.
+if __name__ == "__main__":    
+    api_upload_request()

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -4,8 +4,8 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from rest_framework.test import APIRequestFactory
 from .permissions import DetermineIfStaffPermissions
+from rest_framework.authtoken.models import Token
 from .views import account
-
 
 # Create your tests here.
 def test_func():
@@ -34,6 +34,33 @@ def test_login_form(client):
     #
     #assert response.status_code == 302  # Redirect status code
     #assert response.url == reverse('') # Need to specify an expected login page 
+
+@pytest.mark.django_db
+def test_upload_api(client):
+    '''
+    Set up test cases to ensure the token authentication works and valid data needs to be sent.
+
+    :param client: A client that is provided by pytest. It is used to make get and post requests.
+
+    :Test Cases: TC-037 & TC-038
+    '''
+    # Defining the URL for the api request.
+    url = reverse('upload_api')
+
+    # Making a post request to the URL and asserting that this isn't authorized.
+    response = client.post(url)
+    assert response.status_code == 401
+    
+    # Creating a user with a test username and password and making a token for them.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Making a header to authorize the user to make a post request.
+    headers = { "Authorization": "Token " + userToken.key}
+
+    # Getting the response from the post request and asserting that the user didn't send data and files.
+    response = client.post(url, headers=headers)
+    assert "Could not upload dataset for testuser." in response.text
 
 @pytest.mark.django_db
 def test_account_page(client):

--- a/proj/automodeler/urls.py
+++ b/proj/automodeler/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path("", views.index, name="index"),
     path("upload/", views.upload, name="upload"),
+    path("upload/api", views.upload_api, name="upload_api"),
     path("dataset_delete/<int:dataset_id>", views.dataset_delete, name="dataset_delete"),
     path("dataset/<int:dataset_id>", views.dataset, name="dataset"),
     path("dataset_collection/", views.dataset_collection, name="dataset_collection"),

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -2,8 +2,12 @@ from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.shortcuts import redirect, get_object_or_404
+from rest_framework.authentication import TokenAuthentication
 from django.contrib.auth.decorators import login_required
 from rest_framework.authtoken.models import Token
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from .models import Dataset
 from .forms import DatasetForm
@@ -24,8 +28,50 @@ def index(request):
     :param request: This is the HTTP request object containing the HTTP request information
     """
     return render(request, "automodeler/index.html")
-    
 
+@api_view(["POST"])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def upload_api(request):
+    '''
+    Making an API request to upload a dataset with a csv file and name.
+    Verifying the file name and csv file in this function before anything is uploaded.
+    Letting the user know if a uploading was successful or not.
+
+    :param request: An API request using token authentication. It contains the csv file and name for a dataset.
+    '''
+    # Getting the form used in the API request.
+    form = DatasetForm(request.POST, request.FILES)
+
+    # Ensuring a post request is used and there is at least 1 file in the request.
+    if form.is_valid():
+        # Getting the file name, csv file, and user ID from the request.
+        file_name = request.POST.get('name')
+        csv_file = request.FILES['csv_file']
+        user_id = request.user.id
+
+        # If the dataset is empty let the user know it cannot be uploaded.
+        if csv_file.size > 0:
+            # If the name of the dataset is too long, let the user know it cannot be used.
+            if len(file_name) <= 50:
+                # Using a function to get the features from the dataset.
+                features = extract_features_from_inMemoryUploadedFile(csv_file)
+
+                # Making a datset object and saving it to the user.
+                dataset_model = Dataset.objects.create(name=file_name, features=features, csv_file=csv_file, user_id=user_id)
+                dataset_model.save()
+            else:
+                # Telling the user their file name is too long.
+                return Response("The name has too many characters in it. Could not upload dataset for " + request.user.username + ".")
+        else:
+            # Telling the user their dataset file is empty.
+            return Response("The csv file cannot be empty. Could not upload dataset for " + request.user.username + ".")
+
+        # Informing the user that their uploaded was successful.
+        return Response("Successfully uploaded dataset for " + request.user.username + ".")
+    else:
+        # Informing the user that their uploaded cannot be done.
+        return Response("Could not upload dataset for " + request.user.username + ".")
 
 def upload(request):
     """


### PR DESCRIPTION
Addresses GitHub Issue #23

A user can make an API request to upload datasets. They will need to get an authentication token from their account page. It will be passed with the URL, csv file, and file name. There is an example of making the API request in the api_requests folder. There will be a response letting the user know if the upload was successful or not.