### PR TITLE
API Requests for Modeling and Preprocessing

### DIFF
--- a/api_requests/api_modeling_dataset.py
+++ b/api_requests/api_modeling_dataset.py
@@ -1,0 +1,27 @@
+import requests
+
+def api_modeling_dataset():
+    '''
+    Make an API request to model a dataset.
+    The dataset ID can be found by using api_request_dataset.
+    '''
+    # The URL points to the API request and token authenticates the user.
+    url = "http://localhost:8000/automodeler/mod/start_modeling_request/"
+    token = "ad5c2121066a722d162ce9864ea99e7902371009"
+
+    # Setting the dataset_id which was collected from api_request_dataset.
+    dataset_id = 4
+
+    # The header contains the authorization token to authenticate the user.
+    headers = { "Authorization": "Token " + token}
+
+    # Adding the dataset_id to the data collection so it can be used.
+    data = {"dataset_id": dataset_id}
+
+    # Making a request to model the data and printing the response to know it was complete.
+    response = requests.post(url=url, headers=headers, data=data)
+    print(response.text)
+
+# The main method calls the function to model the dataset.
+if __name__ == "__main__":    
+    api_modeling_dataset()

--- a/api_requests/api_preprocessing_dataset.py
+++ b/api_requests/api_preprocessing_dataset.py
@@ -1,0 +1,27 @@
+import requests
+
+def api_preprocess_dataset():
+    '''
+    Making an API request to preprocess a dataset.
+    The user can know the dataser_id by using the api_request_dataset.
+    '''
+    # Getting the URL and token to be authorized for the API request.
+    url = "http://localhost:8000/automodeler/ppe/start_preprocessing_request/"
+    token = "ad5c2121066a722d162ce9864ea99e7902371009"
+
+    # Setting the dataset_id which was collected from using api_request_dataset.
+    dataset_id = 4
+
+    # Set up a header with the authorization token to authorize the user.
+    headers = { "Authorization": "Token " + token}
+
+    # Added the dataset_id to the data collection to send in the request.
+    data = {"dataset_id": dataset_id}
+
+    # Getting the response from the API request and printing its text to know if it was complete.
+    response = requests.post(url=url, headers=headers, data=data)
+    print(response.text)
+
+# The main method calls the function to preprocess the dataset.
+if __name__ == "__main__":    
+    api_preprocess_dataset()

--- a/proj/automodeler/engine_manager.py
+++ b/proj/automodeler/engine_manager.py
@@ -3,6 +3,10 @@ from django.contrib.auth.decorators import login_required
 from django.core.files.base import ContentFile
 from django.core.exceptions import ObjectDoesNotExist
 
+from rest_framework.authentication import TokenAuthentication, SessionAuthentication
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
+
 from .models import Dataset
 from .models import PreprocessedDataSet
 from .models import DatasetModel
@@ -17,7 +21,9 @@ import pickle
 import json
 
 
-@login_required
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def start_preprocessing_request(request):
     print("Starting preprocessing")
     if request.method != 'POST':
@@ -103,7 +109,9 @@ def start_preprocessing_request(request):
     return HttpResponse("Preprocessing completed...")
 
 
-@login_required
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def start_modeling_request(request):
     print("Starting modeling")
     if request.method != 'POST':


### PR DESCRIPTION
For GitHub Issues #99 & #117 

Changed the engine_manager so the modeling and preprocessing functions accept token authentication. There is an example of making an API request to model and preprocess a dataset. The API Request Dataset pull request is helpful because it would allow someone to get their dataset ID. This is required during the modeling and preprocessing.