### PR TITLE
40 provide login error messages

### DIFF
--- a/proj/accounts/forms.py
+++ b/proj/accounts/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 
 class UserRegisterForm(UserCreationForm):
     username = forms.CharField(label="Username", widget=forms.TextInput(
@@ -10,7 +10,16 @@ class UserRegisterForm(UserCreationForm):
     )
     password1 = forms.CharField(label="Password", widget=forms.PasswordInput(
         attrs={'class' : 'form-control'})
-        )
+    )
     password2 = forms.CharField(label="Confirm Password", widget=forms.PasswordInput(
+        attrs={'class' : 'form-control'})
+    )
+
+
+class UserLoginForm(AuthenticationForm):
+    username = forms.CharField(label="Username", widget=forms.TextInput(
+        attrs={'class': 'form-control'})
+    )
+    password = forms.CharField(label="Password", widget=forms.PasswordInput(
         attrs={'class' : 'form-control'})
     )

--- a/proj/accounts/urls.py
+++ b/proj/accounts/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
 
 from .views import SignUpView
+from .views import LoginView
 
 urlpatterns = [
     #path("signup/", views.signup, name="signup"),
-    path("signup/", SignUpView.as_view(), name="signup")
+    path("signup/", SignUpView.as_view(), name="signup"),
+    path("login/", LoginView.as_view(), name="login"),
 ]

--- a/proj/accounts/views.py
+++ b/proj/accounts/views.py
@@ -1,12 +1,21 @@
 
 from django.urls import reverse_lazy
 from django.views.generic import CreateView
+from django.contrib.auth.views import LoginView
 from django.contrib.messages.views import SuccessMessageMixin
 
 from .forms import UserRegisterForm
+from .forms import UserLoginForm
 
 class SignUpView(SuccessMessageMixin, CreateView):
   template_name = 'registration/signup.html'
   success_url = reverse_lazy('login')
   form_class = UserRegisterForm
   success_message = "Your profile was created successfully"
+
+
+class LoginView(LoginView):
+  template_name = 'registration/login.html'
+  success_url = reverse_lazy('index')
+  form_class = UserLoginForm
+  

--- a/proj/templates/base/navbar.html
+++ b/proj/templates/base/navbar.html
@@ -43,9 +43,6 @@
         </li>
         {% else %}
         <li class="nav-item">
-          <a class="nav-link" href="{% url 'upload' %}">Upload</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href="{% url 'dataset_collection' %}">Datasets</a>
         </li>
         <li class="nav-item">

--- a/proj/templates/registration/login.html
+++ b/proj/templates/registration/login.html
@@ -4,21 +4,33 @@
 
 
 <h2>Log In</h2>
-<div class="container">
-    <!--form method="post" action="/accounts/login/"-->
-    <form method="post" action="{% url 'login' %}">
-        {% csrf_token %}
-    
-        <div class="col-md-3 mb-3">
-            <label for="id_username">Username</label>
-            <input type="text" class="form-control" name="username" autofocus autocapitalize="none" autocomplete="username" maxlength="150" required id="id_username">
-        </div>
-        <div class="col-md-3 mb-3">
-            <label for="id_password">Password</label>
-            <input type="password" class="form-control" name="password" autocomplete="current-password" maxlength="150" required id="id_password">
-        </div>
-        <button type="submit" class="btn btn-primary">Log In</button>
-    </form>    
+<div class="container col-md-3">
+  <form  method="post">
+    {% csrf_token %}
+
+    {% for field in form %}
+
+      <div>
+        {{ field.label_tag }}
+        {{ field }}
+      </div>
+    {% endfor %}
+    <button class="btn btn-info m-3" type="submit">Login</button>
+    {% if form.errors %}
+    <ul class="errorlist">
+        {% for field in form %}
+            {% if field.errors %}
+                {% for error in field.errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+        {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+  </form>
 </div>
 
 {% include "base/footer.html" %}


### PR DESCRIPTION
- Converts the login form at '/accounts/login/' to a Class-based view
- Login form now provides an error message on failed login
- Login form from navbar still functions as normal and provides login error on login page upon failed login

Fix Issue #40 