### PR TITLE
Admin Login in Production

### DIFF
--- a/proj/automodeler/templates/automodeler/model_details.html
+++ b/proj/automodeler/templates/automodeler/model_details.html
@@ -103,7 +103,7 @@ function run_model_request(model_id) {
     });
 }
 
-function pollTaskResult(task_id) {
+function pollTaskResult(task_id, retries=0) {
     fetch(`/automodeler/check_task/${task_id}/`)
     .then(response => {
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);

--- a/proj/modelworx/settings.py
+++ b/proj/modelworx/settings.py
@@ -169,10 +169,13 @@ STATIC_ROOT = os.path.join(BASE_DIR,'staticfiles')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-
 CSRF_TRUSTED_ORIGINS = ["https://modelworx.leviathanworks.net"]
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+SESSION_COOKIE_SECURE = True
+
+CSRF_COOKIE_SECURE = True
 
 LOGIN_REDIRECT_URL = "/automodeler/" # Redirect to automodeler url upon login
 LOGOUT_REDIRECT_URL = "/automodeler/" # Redirect to automodeler url upon logout

--- a/proj/modelworx/urls.py
+++ b/proj/modelworx/urls.py
@@ -25,8 +25,8 @@ router.register('modelworx', ModelWorxViewSet, basename='modelworx') # Routing t
 urlpatterns = [
     path("automodeler/", include("automodeler.urls")),
     path('admin/', admin.site.urls),
-    path('accounts/', include("accounts.urls")), # Used with middleware below
     path('accounts/', include("django.contrib.auth.urls")),
+    path('accounts/', include("accounts.urls")), # Used with middleware below
     #path('', include(router.urls)),
     path('', include("automodeler.urls")),
 ]


### PR DESCRIPTION
 admin login attempts failed silently in production due to Django rejecting insecure session and CSRF cookies over HTTPS.'

Changes:

1. Added SESSION_COOKIE_SECURE = True to settings.py to ensure session cookies are only sent over HTTPS
2. Added CSRF_COOKIE_SECURE = True to settings.py to secure CSRF tokens over HTTPS
3. Fixed model_details polls failure