### PR TITLE
Added django-admin-two-factor

### DIFF
--- a/proj/modelworx/settings.py
+++ b/proj/modelworx/settings.py
@@ -43,6 +43,7 @@ ALLOWED_HOSTS = config("DJANGO_ALLOWED_HOSTS", default="localhost").split(",")
 
 INSTALLED_APPS = [
     'automodeler.apps.AutomodelerConfig',
+    'admin_two_factor.apps.TwoStepVerificationConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -215,4 +216,8 @@ if EMAIL_ENABLED:
   EMAIL_USE_SSL = False
   EMAIL_ADMINS = config('EMAIL_ADMINS')
   EMAIL_SENDER = config('EMAIL_SENDER')
+
+
+# Two Factor App Name
+ADMIN_TWO_FACTOR_NAME = 'Modelworx'
 

--- a/proj/modelworx/urls.py
+++ b/proj/modelworx/urls.py
@@ -29,4 +29,5 @@ urlpatterns = [
     path('accounts/', include("accounts.urls")), # Used with middleware below
     #path('', include(router.urls)),
     path('', include("automodeler.urls")),
+    path('two_factor/', include(('admin_two_factor.urls', 'admin_two_factor'), namespace='two_factor')),
 ]

--- a/requirements
+++ b/requirements
@@ -25,3 +25,4 @@ botocore==1.34.89
 celery>=5.2.0
 rabbitmq-server
 django-celery-results>=2.5
+django-admin-two-factor==0.1.1


### PR DESCRIPTION
- Adds django-admin-two-factor package
- Allows manually adding the requirement for a OTP app (such as Google Authenticator) for admin panel login