### PR TITLE
API Request Run Model

### DIFF
--- a/api_requests/api_check_task_result.py
+++ b/api_requests/api_check_task_result.py
@@ -1,4 +1,3 @@
-import json
 import requests
 
 def api_check_task_result():
@@ -10,17 +9,11 @@ def api_check_task_result():
     url = "http://localhost:8000/automodeler/check_task/520e7549-e1ae-4854-9244-4d29c5c71d50/"
     token = "f0c991d35bdcadea6ba41a3131fb8e3da77b292f"
 
-    # The task ID is collected in the API request to run the model.
-    task_id = "520e7549-e1ae-4854-9244-4d29c5c71d50"
-
     # Added the authentication token to the header to authenticate the user.
     headers = { "Authorization": "Token " + token}
 
-    # Added the task ID to the data so it can be sent and accessed.
-    data = {"task_id": task_id}
-
     # Getting the response after making the API request for task results and printing them.
-    response = requests.post(url=url, headers=headers, data=data)
+    response = requests.post(url=url, headers=headers)
     print(response.text)
 
 # The main method which is used to run the function for the API request.

--- a/api_requests/api_check_task_result.py
+++ b/api_requests/api_check_task_result.py
@@ -1,0 +1,28 @@
+import json
+import requests
+
+def api_check_task_result():
+    '''
+    The API request to get the task results after running a model.
+    '''
+    # Set up the URL and authentication token for the API request.
+    # The URL must contain the task ID.
+    url = "http://localhost:8000/automodeler/check_task/520e7549-e1ae-4854-9244-4d29c5c71d50/"
+    token = "f0c991d35bdcadea6ba41a3131fb8e3da77b292f"
+
+    # The task ID is collected in the API request to run the model.
+    task_id = "520e7549-e1ae-4854-9244-4d29c5c71d50"
+
+    # Added the authentication token to the header to authenticate the user.
+    headers = { "Authorization": "Token " + token}
+
+    # Added the task ID to the data so it can be sent and accessed.
+    data = {"task_id": task_id}
+
+    # Getting the response after making the API request for task results and printing them.
+    response = requests.post(url=url, headers=headers, data=data)
+    print(response.text)
+
+# The main method which is used to run the function for the API request.
+if __name__ == "__main__":    
+    api_check_task_result()

--- a/api_requests/api_run_model.py
+++ b/api_requests/api_run_model.py
@@ -1,0 +1,31 @@
+import json
+import requests
+
+def api_run_model():
+    '''
+    An API request to run a model with input data.
+    '''
+    # Set up the URL and authentication token for the API request.
+    url = "http://localhost:8000/automodeler/mod/run_model/"
+    token = "f0c991d35bdcadea6ba41a3131fb8e3da77b292f"
+
+    # The model ID can be found by running the API to request models.
+    model_id = 15
+
+    # The header contains the authorization token and authenticates a user's request.
+    headers = { "Authorization": "Token " + token}
+
+    # Set up the input values and added them to the request data with the key values, so they can be accessed.
+    input_data = [0, 0, 0, 0, 0, 0, 0, 0]
+    request_data = {"values": input_data}
+
+    # The data contains the model ID and input data to run the model.
+    data = {"model_id": model_id, "data": json.dumps(request_data)}
+
+    # Making the request and getting the response which gives the user the task ID.
+    response = requests.post(url=url, headers=headers, data=data)
+    print(response.text)
+
+# The main method to run the API request to run the model.
+if __name__ == "__main__":    
+    api_run_model()

--- a/proj/automodeler/engine_manager.py
+++ b/proj/automodeler/engine_manager.py
@@ -1,5 +1,3 @@
-from django.contrib.auth.decorators import login_required
-
 from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated

--- a/proj/automodeler/engine_manager.py
+++ b/proj/automodeler/engine_manager.py
@@ -78,7 +78,9 @@ def start_modeling_request(request):
     
     return JsonResponse({"task id": async_results.id})
 
-@login_required
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def run_model(request):
     print("Starting model run")
     if request.method != 'POST':
@@ -125,7 +127,9 @@ def run_model(request):
     
 
 
-@login_required
+@api_view(["GET", "POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def check_task_result(request, task_id):
     result = AsyncResult(task_id)
     if result.ready():

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -253,6 +253,62 @@ def test_request_model(client):
     assert response.status_code == 200
 
 @pytest.mark.django_db
+def test_run_model(client):
+    '''
+    This tests the run model API endpoint. There is a test to verify a user needs to be authenticated.
+    There is another test ensuring an authenticated user has access but they need to send a model ID.
+
+    parm client: The client is used to make API requests and sends back responses with status codes.
+
+    :Test Cases: TC-106 & TC-107
+    '''
+    # Set the URL test the run model API endpoint and getting the response from a request.
+    url = reverse('run_model')
+    response = client.post(url)
+
+    # Asserting that the response is a 403 status code because the user isn't authenticated.
+    assert response.status_code == 403
+    
+    # Creating a test user and assigning them an authentication token.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Adding the authentication token to the header and getting the response from an API request.
+    headers = { "Authorization": "Token " + userToken.key}
+    response = client.post(url, headers=headers)
+
+    # Asserting that there is a 400 status code response because the user did not send a model ID in their request.
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_api_check_task_result(client):
+    '''
+    This is used to test the API enpoint which gets a tasks status. There is a test to verify a user needs to be authenticated.
+    There is also a test to for an authenticated user to verify they have access.
+
+    parm client: The client is used to make the API request and get responses.
+
+    :Test Cases: TC-108 & TC-109
+    '''
+    # Set up a URL to the check task results API endpoint. Put a required argument for the task ID and getting the response from the request.
+    url = reverse('check_task_result', args=["task_id"])
+    response = client.post(url)
+
+    # Asserting that there is a 403 status code response because the user is not authenticated.
+    assert response.status_code == 403
+    
+    # Defining a test user and assigning them an authentication token.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Putting the authentication token in the header to authenticate the user.
+    headers = { "Authorization": "Token " + userToken.key}
+    response = client.post(url, headers=headers)
+
+    # Asserting that this was a valid request, even though a valid task ID wasn't used.
+    assert response.status_code == 200
+
+@pytest.mark.django_db
 def test_account_page(client):
     # Defining the url that will be navigated to.
     url = reverse('account')


### PR DESCRIPTION
GitHub Issue #133

Two functions in the engine_model were set up for API requests and examples of those API requests were added. They include making an API request to run a model and an API request to get the task results. 

To run the model, the request must include the API endpoint, input data, model ID, and authentication token. The use can get the model ID from the API request for all models. The response will give the user the task ID which they can use to get the task results.

To get the task results after running a model. The task ID must be included in an API endpoint that is updated with the task ID, authentication token, and task ID. The results will contain predictions from the model.