### PR TITLE
119-delete-account

### DIFF
--- a/proj/automodeler/templates/automodeler/account.html
+++ b/proj/automodeler/templates/automodeler/account.html
@@ -9,4 +9,8 @@
     <input type="submit" value="Receive Token">
 </form>
 
+<br />
+
+<a href="{% url 'account_delete' %}" class="btn btn-warning">Delete account</a>
+
 {% include "base/footer.html" %}

--- a/proj/automodeler/templates/automodeler/account_delete_confirm.html
+++ b/proj/automodeler/templates/automodeler/account_delete_confirm.html
@@ -1,0 +1,13 @@
+{% include "base/header.html" %}
+{% include "base/navbar.html" %}
+
+
+<h2>Are you sure that you wish to delete your account?</h2>
+<br />
+<h3>All of your associated datasets and models will be deleted</h3>
+<form method="POST">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Confirm Deletion</button>
+</form>
+
+{% include "base/footer.html" %}

--- a/proj/automodeler/urls.py
+++ b/proj/automodeler/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("model_delete/", views.model_delete, name="model_delete"),
     path("task_collection/", views.task_collection, name="task_collection"),
     path("account/", views.account, name="account"),
+    path("account_delete/", views.account_delete, name='account_delete'),
     path("ppe/start_preprocessing_request/", engine_manager.start_preprocessing_request, name="ppe"),
     path("mod/start_modeling_request/", engine_manager.start_modeling_request, name="ame"), # ame = automated model engine
     path("mod/run_model/", engine_manager.run_model, name="run_model"),

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -3,6 +3,8 @@ from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotFound
 from django.urls import reverse
 from django.shortcuts import redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth import logout
+from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.authtoken.models import Token
 
@@ -106,10 +108,13 @@ def dataset(request, dataset_id):
     else:
         return redirect(reverse('login'))
 
+
+@login_required
 def dataset_details(request, dataset_id):
     return render(request, "automodeler/dataset_details.html", {})
 
 
+@login_required
 def account(request):
     """
     Ensuring a user is logged in before giving them access to the account page.
@@ -138,6 +143,19 @@ def account(request):
         # If a user isn't authenticated, navigate to the login page.
         url = reverse("login")
         return HttpResponseRedirect(url)
+
+
+@login_required
+def account_delete(request):
+    if request.method == 'POST':
+        user = request.user
+        logout (request)
+        user.delete()
+        messages.success(request, "Your account has been deleted.")
+        return redirect('index')
+
+    return render(request, 'automodeler/account_delete_confirm.html')
+    
 
 @login_required
 def dataset_collection(request):


### PR DESCRIPTION
- Adds button to accounts page to delete account
- Button links to account confirmation page
- Anything but POST request returns the HTML confirmation page
- Button on confirmation page uses POST request
- Upon successful POST, checks for user in request and deletes the account
- on_delete=CASCADE in models.py should delete all other objects connected to the user account (datasets, preprocessed datasets, models)