### PR TITLE
API Request Dataset Report Download

### DIFF
--- a/api_requests/api_dataset_report_download.py
+++ b/api_requests/api_dataset_report_download.py
@@ -1,0 +1,33 @@
+import requests
+
+def api_dataset_report_download():
+    '''
+    This is an example API request to download a dataset report to a location set by the user.
+    The user will need to update the URL with the dataset ID and set the location to download the file.
+    A response will say if the file was successfully downloaded or now.
+    '''
+    # The URL contains the dataset ID which can be collected from the API request for all datasets.
+    url = "http://localhost:8000/automodeler/report_download/3"
+
+    # The token is from the user's Account page and added to the header to authenticate the user.
+    token = "f0c991d35bdcadea6ba41a3131fb8e3da77b292f" 
+    headers = { "Authorization": "Token " + token}
+
+    # Making the API request and getting the response with the dataset report.
+    response = requests.post(url=url, headers=headers)
+
+    # Ensuring the dataset report was collected before trying to save it to a location set by the user.
+    if (response.status_code == 200):
+        # Downloaded the content in the dataset report.
+        with open("C:\\Users\\jpdun\\Desktop\\dataset_report.pdf", "wb") as dataset_report:
+            dataset_report.write(response.content)
+
+        # Letting the user know that the download was successful
+        print("The dataset report was downloaded successfully.")
+    else:
+        # Letting the user know that the report was not downloaded.
+        print("The dataset report was not dwnloaded successfully.")
+
+# The main method which is used to call the dataset report function.
+if __name__ == "__main__":    
+    api_dataset_report_download()

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -309,6 +309,34 @@ def test_api_check_task_result(client):
     assert response.status_code == 200
 
 @pytest.mark.django_db
+def test_api_dataset_report_download(client):
+    '''
+    The test is for an API request to download a dataset report.
+    There are tests to ensure a user needs to be authenticated and to verify the case when a dataset doesn't exist.
+
+    parm client: The client is used to make an API request and send back a response with the status code.
+
+    :Test Cases: TC-110 & TC-111
+    '''
+    # Setting up the URL to the API endpoint and including the dataset ID as an argument in the URL.
+    url = reverse('report_download', args=[3])
+
+    # Making an API request with the URL and asserting the response is 403 because the user isn't authenticated.
+    response = client.post(url) 
+    assert response.status_code == 403
+    
+    # Defining a test user and assigning them and authentication token.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Adding the authentication token to the header and makking an API request to download a dataset.
+    headers = { "Authorization": "Token " + userToken.key}
+    response = client.post(url, headers=headers)
+
+    # Asserting that the status code response is 404 because the dataset ID wasn't found for the user.
+    assert response.status_code == 404
+
+@pytest.mark.django_db
 def test_account_page(client):
     # Defining the url that will be navigated to.
     url = reverse('account')

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -7,7 +7,9 @@ from django.contrib.auth import logout
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.authtoken.models import Token
-
+from rest_framework.authentication import TokenAuthentication, SessionAuthentication
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
 
 from .models import Dataset, PreprocessedDataSet, DatasetModel, UserTask, ModelingReport, TunedDatasetModel
 from .forms import DatasetForm
@@ -306,7 +308,9 @@ def model_download(request, model_id):
     response['Content-Disposition'] = 'attachment; filename="{0}.bin"'.format(ds_model.name)
     return response
 
-@login_required
+@api_view(["GET", "POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def report_download(request, dataset_id):
     dataset = get_object_or_404(Dataset, pk=dataset_id, user=request.user)
     report_model = get_object_or_404(ModelingReport, original_dataset=dataset, user=request.user)

--- a/proj/modelworx/settings.py
+++ b/proj/modelworx/settings.py
@@ -98,7 +98,15 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-    ]
+    ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '15/min',
+        'user': '15/min'
+    }
 }
 
 # Database


### PR DESCRIPTION
GitHub Issues #26 & #151

Set up a REST API throttle to limit the number of API request to 15 a minute. I tried less but it caused our tests to fail.

A new API request to download the report of a dataset was added. The user must include the dataset ID in the URL for the API endpoint. The location of the download can be changed by the user. The response lets the user know if the request was successful or not. A downloaded report PDF file contains the same information as if it was downloaded from the web application.