### PR TITLE
Updated Model Prediction

### DIFF
--- a/proj/automodeler/api.py
+++ b/proj/automodeler/api.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import api_view, authentication_classes, permissi
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from .models import Dataset, PreprocessedDataSet, TunedDatasetModel
+from .models import Dataset, PreprocessedDataSet, DatasetModel
 from .forms import DatasetForm
 from . import helper_functions
 
@@ -133,7 +133,7 @@ def api_request_models(request):
     :param request: The request parameter is used to get the user's models.
     '''
     # Getting the user's models.
-    user_models = TunedDatasetModel.objects.filter(user=request.user)
+    user_models = DatasetModel.objects.filter(user=request.user)
     
     # Setting up a list to format the response. It contains the model ID which will be helpful in running the model.
     model_information = ["Model Name, " + "Model File Name, " + "Model Method, " + "Model Type" + "Model ID"]

--- a/proj/automodeler/engine_manager.py
+++ b/proj/automodeler/engine_manager.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from django.http import JsonResponse
 from celery.result import AsyncResult
 
-from .models import TunedDatasetModel
+from .models import DatasetModel
 from .models import UserTask
 
 from .tasks import start_preprocessing_task, start_modeling_task, run_model_task
@@ -93,9 +93,9 @@ def run_model(request):
 
     # Get dataset_id from model FK before launching the task
     try:
-        tuned_model = TunedDatasetModel.objects.get(id=model_id, user=request.user)
+        tuned_model = DatasetModel.objects.get(id=model_id, user=request.user)
         dataset_id = tuned_model.original_dataset_id
-    except TunedDatasetModel.DoesNotExist:
+    except DatasetModel.DoesNotExist:
         return JsonResponse({"error": "Tuned model not found"}, status=404)
 
 

--- a/proj/automodeler/engine_manager.py
+++ b/proj/automodeler/engine_manager.py
@@ -93,7 +93,7 @@ def run_model(request):
 
     # Get dataset_id from model FK before launching the task
     try:
-        tuned_model = DatasetModel.objects.get(id=model_id, user=request.user)
+        tuned_model = DatasetModel.objects.get(id=model_id, user=request.user, tuned=True)
         dataset_id = tuned_model.original_dataset_id
     except DatasetModel.DoesNotExist:
         return JsonResponse({"error": "Tuned model not found"}, status=404)

--- a/proj/automodeler/urls.py
+++ b/proj/automodeler/urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
     path("mod/start_modeling_request/", engine_manager.start_modeling_request, name="ame"), # ame = automated model engine
     path("mod/run_model/", engine_manager.run_model, name="run_model"),
     path('check_task/<str:task_id>/', engine_manager.check_task_result, name='check_task_result'),
-    path('test/<int:dataset_id>', views.test, name='test'),
     #path('check_ppe_task/<str:task_id>/', engine_manager.check_preprocessing_task_result, name='check_preprocessing_task_result'),
     #path('check_run_model_task/<str:task_id>/', engine_manager.check_run_model_task_result, name='check_run_model_task_result')
 ]

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -361,7 +361,3 @@ def update_selected_models(request):
     url = reverse('dataset_details', kwargs={'dataset_id': dataset_id})
     return redirect(url)
 
-def test(request, dataset_id):
-    dataset = get_object_or_404(Dataset, pk=dataset_id, user=request.user)
-    pp_ds = get_object_or_404(PreprocessedDataSet, original_dataset=dataset)
-    return HttpResponse("Hello world!  This is the testing page!")

--- a/proj/tests/test_engine_manager.py
+++ b/proj/tests/test_engine_manager.py
@@ -1,6 +1,6 @@
 ﻿import pytest
 from django.urls import reverse
-from automodeler.models import Dataset, DatasetModel, TunedDatasetModel
+from automodeler.models import Dataset, DatasetModel
 from django.contrib.auth import get_user_model
 from unittest.mock import patch, MagicMock
 import json
@@ -63,12 +63,12 @@ def test_run_model_system(client, user_factory):
 
     dataset = Dataset.objects.create(name="Test", user=user, features={"f1": "N"})
 
-    untuned_model = DatasetModel.objects.create(
-        user=user,
-        original_dataset=dataset,
-        model_type="classification",
-        model_file="dummy_untuned_model.pkl"
-    )
+    #untuned_model = DatasetModel.objects.create(
+    #    user=user,
+    #    original_dataset=dataset,
+    #    model_type="classification",
+    #    model_file="dummy_untuned_model.pkl"
+    #)
 
     tuned_model = DatasetModel.objects.create(
         user=user,

--- a/proj/tests/test_engine_manager.py
+++ b/proj/tests/test_engine_manager.py
@@ -70,12 +70,12 @@ def test_run_model_system(client, user_factory):
         model_file="dummy_untuned_model.pkl"
     )
 
-    tuned_model = TunedDatasetModel.objects.create(
+    tuned_model = DatasetModel.objects.create(
         user=user,
         original_dataset=dataset,
         model_type="classification",
         model_file="dummy_model.pkl",
-        untuned_model=untuned_model  
+        tuned=True  
     )
 
     response = client.post(


### PR DESCRIPTION
Goes with GitHub issues #158 

When running a model and making the API request to run a model. It was still using the TunedDatasetModel which was replaced with the DatasetModel. Updating this ensures we can get model predictions again.