### PR TITLE
API Request Delete Model and Delete Dataset

### DIFF
--- a/api_requests/api_request_delete_dataset.py
+++ b/api_requests/api_request_delete_dataset.py
@@ -1,0 +1,22 @@
+import requests
+
+def api_request_delete_dataset():
+    '''
+    This is an API request to delete an uploaded dataset.
+    The dataset ID must be included in the URL when making the request.
+    A user can get the dataset ID by making an API request for all datasets.
+    '''
+    # Defining the URL to delete a dataset and the token to authenticate
+    url = "http://localhost:8000/automodeler/dataset_delete/2"
+    token = "bc35f1ed98772f18c17bb71484e285673d70c4da"
+
+    # Adding the authentication token to the header to validate the user.
+    headers = { "Authorization": "Token " + token}
+
+    # Making the API request and printing the status code to ensure it was successful.
+    response = requests.post(url=url, headers=headers)
+    print(response.status_code)
+
+# The main method is used to run the API request to delete a dataset.
+if __name__ == "__main__":    
+    api_request_delete_dataset()

--- a/api_requests/api_request_delete_model.py
+++ b/api_requests/api_request_delete_model.py
@@ -1,0 +1,27 @@
+import requests
+
+def api_request_delete_model():
+    '''
+    The API request to delete a model that are saved to a user.
+    A user needs to send the model ID which is retreived from an API model request.
+    '''
+    # Setting up the API request delete model URL enpoint and the token to authenticate a user.
+    url = "http://localhost:8000/automodeler/model_delete/"
+    token = "bc35f1ed98772f18c17bb71484e285673d70c4da"
+
+    # Adding the authentication token to the header to authenticate a user.
+    headers = { "Authorization": "Token " + token}
+    
+    # Defining the model ID which will need to be updated with each request.
+    model_id = 15
+
+    # Adding the modle ID to the data so it can be sent in a request.
+    data = {"model_id": model_id}
+
+    # Getting the response from the request to ensure it was successful.
+    response = requests.post(url=url, headers=headers, data=data)
+    print(response.status_code)
+
+# Is used to call the function to make an API request an delete a model.
+if __name__ == "__main__":    
+    api_request_delete_model()

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -394,7 +394,7 @@ def test_api_request_delete_model(client):
     response = client.post(url, headers=headers, data=data)
 
     # Asserting that there was a 404 status code response because the model wasn't found.
-    assert response.status_code == 404;
+    assert response.status_code == 404
 
 @pytest.mark.django_db
 def test_account_page(client):

--- a/proj/automodeler/tests.py
+++ b/proj/automodeler/tests.py
@@ -337,6 +337,66 @@ def test_api_dataset_report_download(client):
     assert response.status_code == 404
 
 @pytest.mark.django_db
+def test_api_request_delete_dataset(client):
+    '''
+    There is a test to ensure the user must be authenticated to make the API request.
+    A second test is used to ensure a dataset can be deleted successfully.
+
+    parm client: Used to make an API request and get a response with the status code.
+
+    :Test Cases: TC-118 & TC-119
+    '''
+    # Setting up the URL to the delete dataset URL enpoint with the dataset ID.
+    url = reverse('dataset_delete', args=[4])
+
+    # Getting the response after the API request and asserting that the user doesn't have access.
+    response = client.post(url) 
+    assert response.status_code == 403
+    
+    # Defining a test user and the authentication token to authenticate the user.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Putting the authentication token in the header and makeing a request with it.
+    headers = { "Authorization": "Token " + userToken.key}
+    response = client.post(url, headers=headers)
+
+    # Asserting that the response has a status code of 302 because the user would be redirceted to the dataset collection.
+    assert response.status_code == 302
+
+@pytest.mark.django_db
+def test_api_request_delete_model(client):
+    '''
+    Has a test to ensure a user must be authenticated.
+    Theres another test to verify a model can be deleted.
+
+    parm client: Used to make the API request and get a response.
+
+    :Test Cases: TC-120 & TC-121
+    '''
+    # The URL for the API endpoint to delete a model.
+    url = reverse('model_delete')
+
+    # Making the API request and asserting that the user wasn't authenticated.
+    response = client.post(url) 
+    assert response.status_code == 403
+    
+    # Making a test user and assigning them an authentication token.
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    userToken, tokenExists = Token.objects.get_or_create(user=user)
+
+    # Created a model ID and assigned it to the data object.
+    model_id = 5
+    data = {"model_id": model_id}
+
+    # Putting the authentication token in the header and making an API request to delete a model.
+    headers = { "Authorization": "Token " + userToken.key}
+    response = client.post(url, headers=headers, data=data)
+
+    # Asserting that there was a 404 status code response because the model wasn't found.
+    assert response.status_code == 404;
+
+@pytest.mark.django_db
 def test_account_page(client):
     # Defining the url that will be navigated to.
     url = reverse('account')

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
@@ -196,15 +197,21 @@ def dataset_collection(request):
     print("Found Datasets: " + str(pp_datasets))
     return render(request, "automodeler/dataset_collection.html", {'combined_datasets': combined_datasets})
 
-@login_required
+@api_view(["GET", "POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def dataset_delete(request, dataset_id):
     if request.method != 'POST':
         return HttpResponse("Invalid request method")
     else:
-        dataset = Dataset.objects.get(id = dataset_id)
-        dataset.delete()
-        url = reverse("dataset_collection")
-        return redirect(url)
+        try:
+            dataset = Dataset.objects.get(id = dataset_id)
+            dataset.delete()
+            url = reverse("dataset_collection")
+            return redirect(url)
+        except Exception:
+            url = reverse("dataset_collection")
+            return redirect(url)
 
 
 @login_required
@@ -254,7 +261,9 @@ def model_collection(request):
     user_models = DatasetModel.objects.filter(user=auth_user, tuned=True)
     return render(request, "automodeler/model_collection.html", {"models": user_models})
 
-@login_required
+@api_view(["GET", "POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def model_delete(request):
     if request.method != 'POST':
         return HttpResponse("Invalid request method")
@@ -262,7 +271,11 @@ def model_delete(request):
     if not model_id:
         return HttpResponse("Empty model id!")
 
-    ds_model = DatasetModel.objects.get(id=model_id)
+    try:
+        ds_model = DatasetModel.objects.get(id=model_id)
+    except Exception:
+        return HttpResponse("Invalid model id!", status=404)
+
 
     if request.POST.get('prev_page'):
         url = reverse(request.POST.get('prev_page'), args=(ds_model.original_dataset.id,))

--- a/proj/automodeler/views.py
+++ b/proj/automodeler/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
-from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes


### PR DESCRIPTION
GitHub Issues #160 & #161

Updated functions used for deleting datasets and models so I can use them for API requests. There is an example of an API request for deleting a dataset. When making this request, the dataset ID, must be included in URL. It can be obtained by making the API requests for all datasets. This also contains the example of an API request for deleting a model. It requires the user to send the model ID in the API request. A user can see all model ID by making the API request for all models. There are tests to ensure a user is authenticated when making a request. There are also tests for the case when an invalid dataset and model ID is used.